### PR TITLE
Add 2 domains in Google group

### DIFF
--- a/proxy-pac.dev.js
+++ b/proxy-pac.dev.js
@@ -54,6 +54,8 @@ var rules = [
   "||groups.google.cn",
   "||gvt0.com",
   "||gvt1.com",
+  "||gvt2.com",
+  "||gvt3.com",
   "||blogspot.tw",
   "||blogspot.com",
 


### PR DESCRIPTION
gvt2.com, gvt3.com.
According to whois information, those 2 domains belong to Google.